### PR TITLE
[ci] Set GITHUB_TOKEN permissions for writing contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
   release:
     needs: [tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Create a new release for the repository
         uses: chaoss/grimoirelab-github-actions/release@master


### PR DESCRIPTION
Setting these permissions allows the workflow to upload the Python package to GitHub.

This is the same as in https://github.com/bitergia-analytics/sortinghat-openinfra/pull/7