### PR TITLE
Upgrade GrimoireLab dependencies 0.13.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -20,13 +20,13 @@ lxml = ["lxml"]
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]
@@ -467,13 +467,13 @@ files = [
 
 [[package]]
 name = "perceval"
-version = "0.22.1"
+version = "0.22.2"
 description = "Send Sir Perceval on a quest to fetch and gather data from software repositories."
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "perceval-0.22.1-py3-none-any.whl", hash = "sha256:dea6dd986faa61d1a376733ff782d9be31ea8e9b6f4cc597a922fdec6a667d6b"},
-    {file = "perceval-0.22.1.tar.gz", hash = "sha256:9a6e2111a9f508f112064d1f27bca68aed18c5f18175023e3e300acfa2a49027"},
+    {file = "perceval-0.22.2-py3-none-any.whl", hash = "sha256:7810f6503aefe326d2fdd076181bda5495a2952bac43621c8ade0c10e4334bdd"},
+    {file = "perceval-0.22.2.tar.gz", hash = "sha256:91f37902f7340e05c0a05a70c5d725b00aef72a31c3e72fe3bfb8182f1a29d8a"},
 ]
 
 [package.dependencies]
@@ -525,13 +525,13 @@ files = [
 
 [[package]]
 name = "pyjwt"
-version = "2.7.0"
+version = "2.8.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "PyJWT-2.7.0-py3-none-any.whl", hash = "sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1"},
-    {file = "PyJWT-2.7.0.tar.gz", hash = "sha256:bd6ca4a3c4285c1a2d4349e5a035fdf8fb94e04ccd0fcbe6ba289dae9cc3e074"},
+    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
+    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
 ]
 
 [package.dependencies]

--- a/releases/unreleased/update-dependencies.yml
+++ b/releases/unreleased/update-dependencies.yml
@@ -1,0 +1,7 @@
+---
+title: Update dependencies
+category: dependency
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: |
+  Dependencies updated to support GrimoireLab 0.13.0.


### PR DESCRIPTION
This commit updates perceval and grimoirelab-toolkit packages to the dependencies available for GrimoireLab 0.13.0.