### PR TITLE
Override metadata method for public-inbox

### DIFF
--- a/perceval/backends/public_inbox/public_inbox.py
+++ b/perceval/backends/public_inbox/public_inbox.py
@@ -193,6 +193,19 @@ class PublicInbox(Git):
         """
         return CATEGORY_MESSAGE
 
+    def metadata(self, item, filter_classified=False):
+        """Public Inbox metadata.
+
+        This method takes items, overriding `metadata` decorator.
+        Ignore Git implementation of metadata() and use the parent.
+
+        :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
+        """
+        item = super(Git, self).metadata(item, filter_classified=filter_classified)
+
+        return item
+
     def _init_client(self, from_archive=False):
         pass
 

--- a/releases/unreleased/metadata-information-in-public-inbox.yml
+++ b/releases/unreleased/metadata-information-in-public-inbox.yml
@@ -1,0 +1,9 @@
+---
+title: Metadata information in Public Inbox
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Public inbox backend was using Git metadata, but in the last version, it
+  now includes information about the commit in the metadata. This change
+  avoid including this information in Public Inbox.


### PR DESCRIPTION
This PR overrides the metadata method from the Git backend and includes the Git parent metadata method. Git is using the commit as the offset and public inbox does not contain commit information in the item.